### PR TITLE
Fixed issue with MathPower not working in Python

### DIFF
--- a/src/marsyas/marsystems/MathPower.cpp
+++ b/src/marsyas/marsystems/MathPower.cpp
@@ -68,7 +68,6 @@ MathPower::myUpdate(MarControlPtr sender)
   ctrl_onObsNames_->setValue(obsNamesAddPrefix(inObsNames,
                              "MathPower_"), NOUPDATE);
 
-  exponent_ = ctrl_exponent_->to<mrs_real>();
 }
 
 void
@@ -76,12 +75,14 @@ MathPower::myProcess(realvec& in, realvec& out)
 {
   mrs_natural t,o;
 
+  mrs_real exponent = ctrl_exponent_->to<mrs_real>();
+
   /// Iterate over the observations and samples and do the processing.
   for (o = 0; o < inObservations_; o++)
   {
     for (t = 0; t < inSamples_; t++)
     {
-      out(o, t) = pow(in(o, t), exponent_);
+      out(o, t) = pow(in(o, t), exponent);
     }
   }
 }

--- a/src/marsyas/marsystems/MathPower.h
+++ b/src/marsyas/marsystems/MathPower.h
@@ -46,7 +46,6 @@ private:
 
   /// MarControlPtr for the gain control
   MarControlPtr ctrl_exponent_;
-  mrs_real exponent_;
 
 public:
   /// MathPower constructor.


### PR DESCRIPTION
When using Python bindings the MathPower exponent control was not being updated.  The MarSystem always return used an exponent of 1 (so the values stayed the same) even when the control was set to another value.  
It appears that updating the member variable exponent_  in the myUpdate function was not working properly when using Python bindings (even though it worked for a MarSystem).  Modified code (based on Gain MarSystem) so that exponent value is obtained from control in the myProcess function.  This addressed the issue with Python bindings.  

If there is a better way to address this let me know.  

Thanks