### PR TITLE
Fix build for qt >= 5.15.0

### DIFF
--- a/src/otherlibs/qwt/qwt_null_paintdevice.h
+++ b/src/otherlibs/qwt/qwt_null_paintdevice.h
@@ -14,6 +14,10 @@
 #include <qpaintdevice.h>
 #include <qpaintengine.h>
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+#include <QPainterPath>
+#endif
+
 /*!
   \brief A null paint device doing nothing
 

--- a/src/otherlibs/qwt/qwt_painter.h
+++ b/src/otherlibs/qwt/qwt_painter.h
@@ -18,6 +18,10 @@
 #include <qline.h>
 #include <qpalette.h>
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+#include <QPainterPath>
+#endif
+
 class QPainter;
 class QBrush;
 class QColor;

--- a/src/otherlibs/qwt/qwt_painter_command.h
+++ b/src/otherlibs/qwt/qwt_painter_command.h
@@ -16,6 +16,10 @@
 #include <qimage.h>
 #include <qpolygon.h>
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+#include <QPainterPath>
+#endif
+
 class QPainterPath;
 
 /*!


### PR DESCRIPTION
src/otherlibs/qwt/*.h:
Add preprocessor instructions to include QPainterPath, when building
against qt >= 5.15.0.

Fixes #77