### PR TITLE
Fix include_directories for vamp plugins

### DIFF
--- a/src/mvamp/CMakeLists.txt
+++ b/src/mvamp/CMakeLists.txt
@@ -14,7 +14,7 @@ set (MVamp_SOURCES
 
 add_library(mvamp SHARED ${MVamp_SOURCES})
 
-include_directories(${VAMP_INCLUDE_DIR})
+include_directories(${VAMP_INCLUDE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../marsyas/marsystems/)
 
 # In case we build the static version of Marsyas, we need to link
 # to that specific archive library. Also linking some additional libs/frameworks


### PR DESCRIPTION
src/mvamp/CMakeLists.txt:
When building the vamp plugins, the include directories for
`MarSystemTemplateBasic.h` and `MarSystemTemplateAdvanced.h`, used in
`src/mvamp/MarsyasIBT.h` are missing.
This change adds `src/marsyas/marsystems` to the `include_directories()`
call, so that the plugins can be built without error.

Fixes #79